### PR TITLE
Add endpoint for dataframe preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ The backend exposes the following API endpoints if you wish to integrate with ot
 - `POST /upload_csv` – upload a CSV file
 - `POST /upload_qif` – upload a QIF file
 - `POST /chat` – send a question about the uploaded data
+- `GET /dataframe` – preview columns and sample rows from the uploaded data
+
+### Example: preview the DataFrame
+
+```bash
+curl "http://localhost:8000/dataframe?sample_rows=5"
+```
+
+This returns JSON with a `columns` list and a `sample` array of rows.
 
 Environment variables allow changing the target Ollama URL and CORS origins (see `docker-compose.yml` and `app/main.py`).
 

--- a/app/main.py
+++ b/app/main.py
@@ -40,7 +40,7 @@ OLLAMA_URL = os.getenv("OLLAMA_BASE_URL", "http://host.docker.internal:11434")
 # Configure the LLM to use Ollama
 llm = OllamaLLM(
     api_base=OLLAMA_URL,
-#    model="phi4-mini:3.8b",
+    #    model="phi4-mini:3.8b",
     model="llama3.1:8b",  # Example model, adjust as needed
 )
 
@@ -48,12 +48,20 @@ llm = OllamaLLM(
 df_storage: dict[str, pd.DataFrame] = {}
 smart_df_storage: dict[str, SmartDataframe] = {}
 
+
 class UploadResponse(BaseModel):
     columns: List[str]
     rows: int
 
+
 class ChatResponse(BaseModel):
     answer: str
+
+
+class DataFrameInfo(BaseModel):
+    columns: List[str]
+    sample: List[dict]
+
 
 @app.post("/upload_csv", response_model=UploadResponse)
 async def upload_csv(file: UploadFile = File(...)):
@@ -70,6 +78,7 @@ async def upload_csv(file: UploadFile = File(...)):
     except Exception as e:
         logger.error("CSV parse error: %s", e)
         raise HTTPException(500, f"Unable to parse CSV: {e}")
+
 
 @app.post("/upload_qif", response_model=UploadResponse)
 async def upload_qif(file: UploadFile = File(...)):
@@ -89,11 +98,14 @@ async def upload_qif(file: UploadFile = File(...)):
         logger.error("QIF parse error: %s", e)
         raise HTTPException(500, f"Unable to parse QIF: {e}")
 
+
 @app.post("/chat", response_model=ChatResponse)
 async def chat_query(question: str = Form(...)):
     smart_df = smart_df_storage.get("smart_df")
     if smart_df is None:
-        raise HTTPException(400, "No data uploaded. POST to /upload_csv or /upload_qif first.")
+        raise HTTPException(
+            400, "No data uploaded. POST to /upload_csv or /upload_qif first."
+        )
     if not question.strip():
         raise HTTPException(400, "Question must not be empty.")
     try:
@@ -103,3 +115,20 @@ async def chat_query(question: str = Form(...)):
     except Exception as e:
         logger.error("Chat error: %s", e)
         raise HTTPException(500, f"Failed to process question: {e}")
+
+
+@app.get("/dataframe", response_model=DataFrameInfo)
+async def get_dataframe(sample_rows: int = 5):
+    """Return columns and a sample of rows from the uploaded DataFrame."""
+    smart_df = smart_df_storage.get("smart_df")
+    if smart_df is None:
+        raise HTTPException(
+            400,
+            "No data uploaded. POST to /upload_csv or /upload_qif first.",
+        )
+    try:
+        sample = smart_df.head(sample_rows).to_dict(orient="records")
+        return DataFrameInfo(columns=list(smart_df.columns), sample=sample)
+    except Exception as e:
+        logger.error("Data preview error: %s", e)
+        raise HTTPException(500, f"Failed to fetch dataframe preview: {e}")


### PR DESCRIPTION
## Summary
- expose a new `GET /dataframe` endpoint
- return dataframe columns and sample rows without using the LLM

## Testing
- `python3 -m py_compile app/main.py`
- `black app/main.py --check`

------
https://chatgpt.com/codex/tasks/task_e_684c54c0dd6c832398c7d17d06b9df75