### PR TITLE
Fix dataframe endpoint for curl

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -120,15 +120,15 @@ async def chat_query(question: str = Form(...)):
 @app.get("/dataframe", response_model=DataFrameInfo)
 async def get_dataframe(sample_rows: int = 5):
     """Return columns and a sample of rows from the uploaded DataFrame."""
-    smart_df = smart_df_storage.get("smart_df")
-    if smart_df is None:
+    df = df_storage.get("df")
+    if df is None:
         raise HTTPException(
             400,
             "No data uploaded. POST to /upload_csv or /upload_qif first.",
         )
     try:
-        sample = smart_df.head(sample_rows).to_dict(orient="records")
-        return DataFrameInfo(columns=list(smart_df.columns), sample=sample)
+        sample = df.head(sample_rows).to_dict(orient="records")
+        return DataFrameInfo(columns=df.columns.tolist(), sample=sample)
     except Exception as e:
         logger.error("Data preview error: %s", e)
         raise HTTPException(500, f"Failed to fetch dataframe preview: {e}")


### PR DESCRIPTION
## Summary
- revert Streamlit file preview changes
- simplify `/dataframe` endpoint to use the stored DataFrame directly

## Testing
- `python -m py_compile app/*.py ui/streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_684c6bbad6cc83239588f88f67e4b879